### PR TITLE
Survey ref is now alphanumeric

### DIFF
--- a/app/templates/surveys.html
+++ b/app/templates/surveys.html
@@ -20,7 +20,7 @@
         <form action="/survey">
             <div class="form-group">
                 <label for="survey_ref">Survey Ref</label>
-                <input class="form-control" type="number" id="survey_ref" name="survey_ref">
+                <input class="form-control" type="text" id="survey_ref" name="survey_ref">
             </div>
             <div class="form-group">
                 <label for="short_name">Short Name</label>


### PR DESCRIPTION
# Motivation and Context
https://github.com/ONSdigital/rm-survey-service/pull/55 made surveyRef
alphanumeric so removing number validation.

# What has changed
Make field "text"

# How to test?
1. `make up` in ras-rm-docker-dev
1. `make docker-run` in rasrm-ops
1. Create a survey with alphanumeric surveyRef