### PR TITLE
Remove logic to exclude domain suffix in prod

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,8 +5,6 @@ cf_env = cfenv.AppEnv()
 
 
 def env_path(environment):
-    if environment == 'prod':
-        return ''
     return f"-{environment}"
 
 
@@ -19,12 +17,12 @@ class Config:
 
     if cf_env.app:
         ENVIRONMENT = cf_env.space
-        ACTION_SERVICE = f"http://actionsvc{env_path(ENVIRONMENT)}.{SERVICE_DOMAIN_SUFFIX}"
-        COLLECTION_EXERCISE_SERVICE = f"http://collectionexercisesvc{env_path(ENVIRONMENT)}.{SERVICE_DOMAIN_SUFFIX}"
-        COLLECTION_INSTRUMENT_SERVICE = f"http://ras-collection-instrument{env_path(ENVIRONMENT)}." \
+        ACTION_SERVICE = f"http://actionsvc-{ENVIRONMENT}.{SERVICE_DOMAIN_SUFFIX}"
+        COLLECTION_EXERCISE_SERVICE = f"http://collectionexercisesvc-{ENVIRONMENT}.{SERVICE_DOMAIN_SUFFIX}"
+        COLLECTION_INSTRUMENT_SERVICE = f"http://ras-collection-instrument-{ENVIRONMENT}." \
                                         f"{SERVICE_DOMAIN_SUFFIX}"
-        SAMPLE_SERVICE = f"http://samplesvc{env_path(ENVIRONMENT)}.{SERVICE_DOMAIN_SUFFIX}"
-        SURVEY_SERVICE = f"http://surveysvc{env_path(ENVIRONMENT)}.{SERVICE_DOMAIN_SUFFIX}"
+        SAMPLE_SERVICE = f"http://samplesvc-{ENVIRONMENT}.{SERVICE_DOMAIN_SUFFIX}"
+        SURVEY_SERVICE = f"http://surveysvc-{ENVIRONMENT}.{SERVICE_DOMAIN_SUFFIX}"
 
 
 class CIConfig(Config):


### PR DESCRIPTION
# Motivation and Context
It was thought that the apps in prod didn't have a prod domain suffix so
there was logic to remove the $space environment variable from the
domain.

# What has changed
Remove invalid domain suffix logic

# How to test?
Domain should be rasrm-ops.$SUFFIX

# Links
https://trello.com/c/x78XX7rf/245-dev-utility
