### PR TITLE
EQ_ID and FORM_TYPE are default selectors for CI

### DIFF
--- a/app/views/ci.py
+++ b/app/views/ci.py
@@ -67,6 +67,8 @@ def get_ci_classifiers(survey_id):
         classifiers_for_id = get_ci_classifier(survey_id, classifier_id)
         for classifier in classifiers_for_id['classifierTypes']:
             classifiers[classifier] = ''
+    classifiers['EQ_ID'] = ''
+    classifiers['FORM_TYPE'] = ''
     return classifiers
 
 

--- a/app/views/survey_classifier.py
+++ b/app/views/survey_classifier.py
@@ -17,8 +17,8 @@ def get_survey_classifier(survey_id):
     survey = get_survey(survey_id)
     return render_template('survey_classifiers.html',
                            classifier_types=classifier_selector_types,
-                           classifiers=["COLLECTION_EXERCISE", "RU_REF", "REGION", "LEGAL_BASIS", "FORM_TYPE",
-                                        "SAMPLE_REF", "EQ_ID"], survey=survey, survey_id=survey_id)
+                           classifiers=["COLLECTION_EXERCISE", "RU_REF", "REGION", "LEGAL_BASIS", "SAMPLE_REF"],
+                           survey=survey, survey_id=survey_id)
 
 
 @blueprint.route('/survey/<survey_id>/classifiers', methods=["POST"])

--- a/tests/views/test_ci.py
+++ b/tests/views/test_ci.py
@@ -21,20 +21,33 @@ def test_get_ci_shows_all_selectors(client, requests_mock):
     assert b'RU_REF' in response.data
 
 
-def test_create_ci_classifier(client, requests_mock):
-    requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
+def test_eq_id_selector_is_default(client, requests_mock):
+    requests_mock.get('/collectionexercises/123', json={})
+    requests_mock.get('/surveys/BRES/classifiertypeselectors',
+                      json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
     requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
-                      json={'classifierTypes': ['COLLECTION_EXERCISE_ID']})
-    requests_mock.post('/collection-instrument-api/1.0.2/upload')
-    requests_mock.get('/collection-instrument-api/1.0.2/collectioninstrument', json=[{'id': 'ci_id'}])
-    requests_mock.post('/collection-instrument-api/1.0.2/link-exercise/ci_id/collex_id')
+                      json={'classifierTypes': ['RU_REF', 'COLLECTION_EXERCISE_ID']})
+    requests_mock.get('/surveys/BRES', json={})
 
-    response = client.post('/survey/BRES/collection/collex_id/ci', data={'COLLECTION_EXERCISE_ID': 'collex_id'})
+    response = client.get('/survey/BRES/collection/123/ci')
 
-    assert response.status_code == 302
+    assert b'EQ_ID' in response.data
 
 
-def test_create_ci_classifier_no_classifiers(client, requests_mock):
+def test_form_type_selector_is_default(client, requests_mock):
+    requests_mock.get('/collectionexercises/123', json={})
+    requests_mock.get('/surveys/BRES/classifiertypeselectors',
+                      json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
+    requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
+                      json={'classifierTypes': []})
+    requests_mock.get('/surveys/BRES', json={})
+
+    response = client.get('/survey/BRES/collection/123/ci')
+
+    assert b'FORM_TYPE' in response.data
+
+
+def test_create_ci_classifier_default_classifiers(client, requests_mock):
     requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
     requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
                       json={'classifierTypes': []})
@@ -42,31 +55,45 @@ def test_create_ci_classifier_no_classifiers(client, requests_mock):
     requests_mock.get('/collection-instrument-api/1.0.2/collectioninstrument', json=[{'id': 'ci_id'}])
     requests_mock.post('/collection-instrument-api/1.0.2/link-exercise/ci_id/collex_id')
 
-    response = client.post('/survey/BRES/collection/collex_id/ci')
+    response = client.post('/survey/BRES/collection/collex_id/ci', data={'EQ_ID': '1', 'FORM_TYPE': '2'})
 
     assert response.status_code == 302
 
 
-def test_create_ci_classifier_link_fails(client, requests_mock):
-    requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
-    requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
-                      json={'classifierTypes': ['COLLECTION_EXERCISE_ID']})
-    requests_mock.post('/collection-instrument-api/1.0.2/upload', status_code=500)
-
-    response = client.post('/survey/BRES/collection/collex_id/ci', data={'COLLECTION_EXERCISE_ID': 'collex_id'})
-
-    assert response.status_code == 500
-
-
-def test_create_ci_classifier_link_conflict(client, requests_mock):
+def test_create_ci_classifier_with_non_default_selector(client, requests_mock):
     requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[{'name': 'COLLECTION_INSTRUMENT', 'id': '123'}])
     requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
                       json={'classifierTypes': ['COLLECTION_EXERCISE_ID']})
     requests_mock.post('/collection-instrument-api/1.0.2/upload')
     requests_mock.get('/collection-instrument-api/1.0.2/collectioninstrument', json=[{'id': 'ci_id'}])
+    requests_mock.post('/collection-instrument-api/1.0.2/link-exercise/ci_id/collex_id')
+
+    response = client.post('/survey/BRES/collection/collex_id/ci',
+                           data={'COLLECTION_EXERCISE_ID': 'collex_id', 'EQ_ID': '1', 'FORM_TYPE': '2'})
+
+    assert response.status_code == 302
+
+
+def test_create_ci_classifier_link_fails(client, requests_mock):
+    requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[])
+    requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
+                      json={'classifierTypes': []})
+    requests_mock.post('/collection-instrument-api/1.0.2/upload', status_code=500)
+
+    response = client.post('/survey/BRES/collection/collex_id/ci', data={'EQ_ID': '1', 'FORM_TYPE': '2'})
+
+    assert response.status_code == 500
+
+
+def test_create_ci_classifier_link_conflict(client, requests_mock):
+    requests_mock.get('/surveys/BRES/classifiertypeselectors', json=[])
+    requests_mock.get('/surveys/BRES/classifiertypeselectors/123',
+                      json={'classifierTypes': []})
+    requests_mock.post('/collection-instrument-api/1.0.2/upload')
+    requests_mock.get('/collection-instrument-api/1.0.2/collectioninstrument', json=[{'id': 'ci_id'}])
     requests_mock.post('/collection-instrument-api/1.0.2/link-exercise/ci_id/collex_id', status_code=409)
 
-    response = client.post('/survey/BRES/collection/collex_id/ci', data={'COLLECTION_EXERCISE_ID': 'collex_id'})
+    response = client.post('/survey/BRES/collection/collex_id/ci', data={'EQ_ID': '1', 'FORM_TYPE': '2'})
 
     assert response.status_code == 409
 


### PR DESCRIPTION
# Motivation and Context
These selectors shouldn't need to be added to the survey selector types

# What has changed
EQ_ID and FORM_TYPE are allowed to be set without setting them as survey selectors

# How to test?
1. Create a survey
2. Set EQ_ID and FORM_TYPE and check it's stored
