### PR TITLE
Push Docker images to GCR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,27 @@ cache:
   - pip
 
 env:
-  - APP_SETTINGS=DevConfig
+  global:
+    - APP_SETTINGS=DevConfig
+    - PIPENV_IGNORE_VIRTUALENVS=1
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-ops"
 
 install:
   - pip install pipenv
   - pipenv install --dev --deploy
 
 script:
+  - pipenv check
   - make test
 
 after_success:
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_PULL_REQUEST_BRANCH" == "automate-census-docker-build" ]); then
+  docker build -t "$DESTINATION_IMAGE_NAME" .;
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker push "$DESTINATION_IMAGE_NAME";
+  fi
   - pipenv run codecov
 
 branches:
   only:
-    - master
+    - rm-census


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/dC6sEWqE/443-set-up-automated-docker-image-build)